### PR TITLE
enforce limitations on package name from the registry

### DIFF
--- a/packages/registry/contracts/CannonRegistry.sol
+++ b/packages/registry/contracts/CannonRegistry.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.8.11;
 
 contract CannonRegistry {
   error Unauthorized();
-  error InvalidUrl();
+  error InvalidUrl(string url);
+  error InvalidName(bytes32 name);
 
   event ProtocolPublish(bytes32 indexed name, bytes32 indexed version, bytes32[] indexed tags, string url, address owner);
+
+  uint public constant MIN_PACKAGE_NAME_LENGTH = 3;
 
   mapping(bytes32 => mapping(bytes32 => string)) public urls;
   mapping(bytes32 => address) public owners;
@@ -15,9 +18,40 @@ contract CannonRegistry {
 
   mapping(bytes32 => address) public nominatedOwner;
 
+  function validateName(bytes32 name) public pure returns (bool) {
+    // each character must be in the supported charset
+
+    for (uint i = 0;i < 32;i++) {
+      if (name[i] == bytes1(0)) {
+        // must be long enough
+        if (i < MIN_PACKAGE_NAME_LENGTH) {
+          return false;
+        }
+
+        // last character cannot be `-`
+        if (name[i - 1] == "-") {
+          return false;
+        }
+
+        break;
+      }
+
+      // must be in valid character set
+      if ((name[i] < "0" || name[i] > "9") &&
+          (name[i] < "a" || name[i] > "z") &&
+          // first character cannot be `-`
+          (i == 0 || name[i] != "-")
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   function publish(bytes32 _name, bytes32 _version, bytes32[] memory _tags, string memory _url) external {
     if (bytes(_url).length == 0) {
-      revert InvalidUrl();
+      revert InvalidUrl(_url);
     }
 
     if (owners[_name] != address(0) && owners[_name] != msg.sender) {
@@ -25,6 +59,11 @@ contract CannonRegistry {
     }
 
     if (owners[_name] == address(0)) {
+
+      if (!validateName(_name)) {
+        revert InvalidName(_name);
+      }
+
       owners[_name] = msg.sender;
       protocols.push(_name);
     }

--- a/packages/registry/test/contracts/CannonRegistry.test.ts
+++ b/packages/registry/test/contracts/CannonRegistry.test.ts
@@ -20,6 +20,36 @@ describe('CannonRegistry', function () {
     [user1, user2, user3] = await ethers.getSigners();
   });
 
+  describe('validateName', () => {
+    it('only allows lowercase letters, numbers, and dashes', async () => {
+      equal(await registry.validateName(toBytes32('some--mo-du9le')), true);
+      equal(await registry.validateName(toBytes32('some_-mo-du9le')), false);
+      equal(await registry.validateName(toBytes32('some--mo-du9lE')), false);
+      // todo: use some hidden character or something
+    });
+
+    it('does not allow dash at beginning or end', async () => {
+      equal(await registry.validateName(toBytes32('some--module-')), false);
+      equal(await registry.validateName(toBytes32('-some--module')), false);
+    });
+
+    it('enforces minimum length', async () => {
+      const testName = 'abcdefghijk';
+      const minLength = await registry.MIN_PACKAGE_NAME_LENGTH();
+
+      equal(
+        await registry.validateName(toBytes32(testName.slice(0, minLength))),
+        true
+      );
+      equal(
+        await registry.validateName(
+          toBytes32(testName.slice(0, minLength - 1))
+        ),
+        false
+      );
+    });
+  });
+
   describe('publish()', () => {
     it('should not allow to publish empty url', async function () {
       await assertRevert(async () => {
@@ -29,7 +59,18 @@ describe('CannonRegistry', function () {
           [],
           ''
         );
-      }, 'InvalidUrl()');
+      }, 'InvalidUrl("")');
+    });
+
+    it('should not allow invalid name', async function () {
+      await assertRevert(async () => {
+        await registry.publish(
+          toBytes32('some-module-'),
+          toBytes32('0.0.1'),
+          [],
+          'ipfs://some-module-hash@0.0.1'
+        );
+      }, 'InvalidName("0x736f6d652d6d6f64756c652d0000000000000000000000000000000000000000")');
     });
 
     it('should create the first protocol and assign the owner', async function () {


### PR DESCRIPTION
for security reasons, we want limit the potential package identifiers an attacker could use in oredr to publish fake packages.

this should restrict the package name to a safe charset, one that:

* only allows lowercase letters, numbers, and dashes
* prevents dashes at beginning or end
* ensures a minimum reasonable length (maximum is enforced by bytes32 limit)