### PR TITLE
minor contract deployer step improvements

### DIFF
--- a/packages/hardhat-cannon/src/builder/invoke.ts
+++ b/packages/hardhat-cannon/src/builder/invoke.ts
@@ -4,6 +4,7 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 
 import { ChainBuilderContext } from './';
+import { getExecutionSigner } from './util';
 
 const debug = Debug('cannon:builder:invoke');
 
@@ -69,10 +70,12 @@ export default {
   async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<Outputs> {
     debug('exec', config);
 
+    const signer = await getExecutionSigner(hre, '');
+
     const contract = new hre.ethers.Contract(
       config.address,
       JSON.parse(config.abi),
-      (await hre.ethers.getSigners())[0]
+      signer
     );
 
     const txn = await contract[config.func](...(config.args || []));

--- a/packages/hardhat-cannon/src/builder/util.ts
+++ b/packages/hardhat-cannon/src/builder/util.ts
@@ -1,3 +1,7 @@
+import { ethers } from 'ethers';
+import crypto from 'crypto';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
 export const ChainDefinitionScriptSchema = {
   properties: {
     exec: { type: 'string' },
@@ -7,3 +11,24 @@ export const ChainDefinitionScriptSchema = {
     env: { elements: { type: 'string' } },
   },
 } as const;
+
+export async function getExecutionSigner(
+  hre: HardhatRuntimeEnvironment,
+  seed: string
+): Promise<ethers.Signer> {
+  const hash = crypto.createHash('sha256').update(seed, 'hex').digest('hex');
+  const address = '0x' + hash.slice(0, 40);
+
+  // ensure this account has a balance
+  await hre.ethers.provider.send('hardhat_impersonateAccount', [address]);
+
+  await hre.ethers.provider.send('hardhat_setBalance', [
+    address,
+    hre.ethers.utils.parseEther('2').toHexString(),
+  ]);
+
+
+  const signer = hre.ethers.getSigner(address);
+
+  return signer;
+}

--- a/packages/sample-project/cannonfile.toml
+++ b/packages/sample-project/cannonfile.toml
@@ -8,9 +8,15 @@ defaultValue = "greeter"
 [setting.msg]
 defaultValue = "Hello world!"
 
+[contract.library]
+artifact = "Library"
+
 [contract.greeter]
 artifact = "Greeter"
 args = ["<%= settings.msg %>"]
+libraries.Library = ["<%= outputs.self.contracts.library.address %>"]
 salt = "<%= settings.salt %>"
 detect.method = "folder"
 detect.path = "deployments/${network}"
+
+step = 1

--- a/packages/sample-project/contracts/Greeter.sol
+++ b/packages/sample-project/contracts/Greeter.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
 
+import "./Library.sol";
+
 contract Greeter {
     string private greeting;
 
@@ -12,6 +14,7 @@ contract Greeter {
     }
 
     function greet() public view returns (string memory) {
+        Library.testLibraryFunction();
         return greeting;
     }
 

--- a/packages/sample-project/contracts/Library.sol
+++ b/packages/sample-project/contracts/Library.sol
@@ -1,0 +1,10 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "hardhat/console.sol";
+
+library Library {
+    function testLibraryFunction() public view {
+        console.log("The library is logging");
+    }
+}


### PR DESCRIPTION
* add support for linking libraries
   * NOTE: the library is to be deployed with a prior `contract` action,
     similar to how a contract is deployed right now. After much thought
     on the architecture of the matter, this makes the most sense
     for our future ambition
* add randomized address support

in the not-so distant future randomized address will be replaced with
the user's own deployment address which they can supply through hardhat.
Other than that, deployments to live chains should be very similar