### PR TITLE
add ability to write deployment files

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,9 +5,9 @@ name: Verify
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/packages/hardhat-cannon/src/index.ts
+++ b/packages/hardhat-cannon/src/index.ts
@@ -5,6 +5,7 @@ import './tasks/build';
 import './tasks/publish';
 import './subtasks/download';
 import './subtasks/load-deploy';
+import './subtasks/write-deployments';
 import './type-extensions';
 
 import { HardhatConfig, HardhatUserConfig } from 'hardhat/types';
@@ -12,6 +13,8 @@ import { extendConfig } from 'hardhat/config';
 
 extendConfig(
   (config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
+    config.paths.deployments = userConfig.paths?.deployments ?? 'deployments';
+
     config.cannon = {
       registryEndpoint:
         userConfig.cannon?.registryEndpoint ||

--- a/packages/hardhat-cannon/src/subtasks/write-deployments.ts
+++ b/packages/hardhat-cannon/src/subtasks/write-deployments.ts
@@ -1,0 +1,55 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { subtask } from 'hardhat/config';
+
+import { SUBTASK_WRITE_DEPLOYMENTS } from '../task-names';
+import { BundledChainBuilderOutputs } from '../builder';
+import { printBundledChainBuilderOutput } from '../printer';
+import { any } from 'hardhat/internal/core/params/argumentTypes';
+
+subtask(SUBTASK_WRITE_DEPLOYMENTS)
+  .addParam('outputs', 'Output object from the chain builder', null, any)
+  .addOptionalParam(
+    'modules',
+    'Which modules to output deployments for. Comma separated (default: `self`)',
+    'self'
+  )
+  .setAction(
+    async (
+      {
+        outputs,
+        modules,
+      }: { outputs: BundledChainBuilderOutputs; modules: string },
+      hre
+    ): Promise<void> => {
+      const deploymentPath = path.resolve(
+        hre.config.paths.deployments,
+        hre.network.name
+      );
+
+      await fs.mkdirp(deploymentPath);
+
+      // find all contract deployment addresses for the selected modules and put them in a file
+      for (const module of modules.split(',')) {
+        for (const contract in outputs[module].contracts) {
+          const file = path.join(deploymentPath, `${contract}.json`);
+
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const contractOutputs = outputs[module].contracts![contract];
+
+          const transformedOutput = {
+            ...contractOutputs,
+            abi: JSON.parse(contractOutputs.abi as string),
+          };
+
+          // JSON format is already correct, so we can just output what we have
+          await fs.writeFile(file, JSON.stringify(transformedOutput, null, 2));
+        }
+      }
+
+      // neatly print also
+      printBundledChainBuilderOutput(outputs);
+
+      console.log('wrote deployment artifacts:', deploymentPath);
+    }
+  );

--- a/packages/hardhat-cannon/src/task-names.ts
+++ b/packages/hardhat-cannon/src/task-names.ts
@@ -6,3 +6,4 @@ export const TASK_PUBLISH = `${TASK_PREFIX}:publish`;
 
 export const SUBTASK_LOAD_DEPLOY = `${TASK_PREFIX}:load-deploy`;
 export const SUBTASK_DOWNLOAD = `${TASK_PREFIX}:download`;
+export const SUBTASK_WRITE_DEPLOYMENTS = `${TASK_PREFIX}:write-deployments`;

--- a/packages/hardhat-cannon/src/tasks/cannon.ts
+++ b/packages/hardhat-cannon/src/tasks/cannon.ts
@@ -6,6 +6,7 @@ import { ChainBuilder } from '../builder';
 import {
   SUBTASK_DOWNLOAD,
   SUBTASK_LOAD_DEPLOY,
+  SUBTASK_WRITE_DEPLOYMENTS,
   TASK_CANNON,
 } from '../task-names';
 import { printBundledChainBuilderOutput } from '../printer';
@@ -54,10 +55,9 @@ task(TASK_CANNON, 'Provision the current cannon.json file using Cannon')
           await builder.build(provision[1]);
         }
 
-        console.log(
-          `${typeof provision == 'string' ? provision : provision[0]} outputs:`
-        );
-        printBundledChainBuilderOutput(builder.getOutputs());
+        await hre.run(SUBTASK_WRITE_DEPLOYMENTS, {
+          outputs: builder.getOutputs(),
+        });
       }
 
       await hre.run('node');

--- a/packages/hardhat-cannon/src/type-extensions.ts
+++ b/packages/hardhat-cannon/src/type-extensions.ts
@@ -3,6 +3,9 @@ import 'hardhat/types/config';
 import { Options as IPFSConnectionOptions } from 'ipfs-http-client';
 
 declare module 'hardhat/types/config' {
+  export interface ProjectPathsUserConfig {
+    deployments?: string;
+  }
   export interface HardhatUserConfig {
     cannon?: {
       registryEndpoint?: string;
@@ -10,6 +13,10 @@ declare module 'hardhat/types/config' {
       publisherPrivateKey?: string;
       ipfsConnection?: IPFSConnectionOptions;
     };
+  }
+
+  export interface ProjectPathsConfig {
+    deployments: string;
   }
 
   export interface HardhatConfig {

--- a/packages/sample-project/.gitignore
+++ b/packages/sample-project/.gitignore
@@ -1,3 +1,4 @@
 artifacts/
 cache/
 typechain/
+deployments/


### PR DESCRIPTION
this will allow for frontends or other testing tools to use cannon projects directly
for prototyping or frontend dev with no inconveniences.

this can be customized by the downstream project if they want using a `subtask` override