### PR TITLE
invoke improvements

### DIFF
--- a/packages/hardhat-cannon/src/builder/invoke.ts
+++ b/packages/hardhat-cannon/src/builder/invoke.ts
@@ -4,19 +4,28 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { JTDDataType } from 'ajv/dist/core';
 
 import { ChainBuilderContext } from './';
-import { getExecutionSigner } from './util';
+import { getExecutionSigner, initializeSigner } from './util';
+import { ethers } from 'ethers';
 
 const debug = Debug('cannon:builder:invoke');
 
 const config = {
   properties: {
-    address: { type: 'string' },
+    addresses: { elements: { type: 'string' } },
     abi: { type: 'string' },
     func: { type: 'string' },
   },
   optionalProperties: {
     args: { elements: {} },
     from: { type: 'string' },
+    fromCall: {
+      properties: {
+        func: { type: 'string' },
+      },
+      optionalProperties: {
+        args: { elements: {} },
+      },
+    },
     detect: {
       properties: {
         func: { type: 'string' },
@@ -32,8 +41,11 @@ const config = {
 
 export type Config = JTDDataType<typeof config>;
 
+export type EncodedTxnEvents = { [name: string]: { args: any[] }[] };
+
 export interface Outputs {
-  hash: string;
+  hashes: string[];
+  events?: EncodedTxnEvents[];
 }
 
 // ensure the specified contract is already deployed
@@ -55,12 +67,23 @@ export default {
   configInject(ctx: ChainBuilderContext, config: Config) {
     config = _.cloneDeep(config);
 
-    config.address = _.template(config.address)(ctx);
+    config.addresses = config.addresses.map((a) => _.template(a)(ctx));
     config.abi = _.template(config.abi)(ctx);
     config.func = _.template(config.func)(ctx);
 
     if (config.args) {
       config.args = _.map(config.args, (a) => {
+        return typeof a == 'string' ? _.template(a)(ctx) : a;
+      });
+    }
+
+    if (config.from) {
+      config.from = _.template(config.from)(ctx);
+    }
+
+    if (config.fromCall) {
+      config.fromCall.func = _.template(config.fromCall.func)(ctx);
+      config.fromCall.args = _.map(config.fromCall.args, (a) => {
         return typeof a == 'string' ? _.template(a)(ctx) : a;
       });
     }
@@ -71,19 +94,61 @@ export default {
   async exec(hre: HardhatRuntimeEnvironment, config: Config): Promise<Outputs> {
     debug('exec', config);
 
-    const signer = await getExecutionSigner(hre, '');
+    const hashes = [];
+    const events: EncodedTxnEvents[] = [];
 
-    const contract = new hre.ethers.Contract(
-      config.address,
-      JSON.parse(config.abi),
-      signer
-    );
+    const mainSigner = config.from
+      ? await initializeSigner(hre, config.from)
+      : await getExecutionSigner(hre, '');
 
-    const txn = await contract[config.func](...(config.args || []));
-    const receipt = await txn.wait();
+    for (const address of config.addresses) {
+      const contract = new hre.ethers.Contract(address, JSON.parse(config.abi));
+
+      let txn: ethers.ContractTransaction;
+
+      if (config.fromCall) {
+        const address = contract[config.fromCall.func](
+          ...(config.fromCall?.args || [])
+        );
+
+        const callSigner = await initializeSigner(hre, address);
+
+        txn = await contract
+          .connect(callSigner)
+          [config.func](...(config.args || []));
+      } else {
+        txn = await contract
+          .connect(mainSigner)
+          [config.func](...(config.args || []));
+      }
+
+      const receipt = await txn.wait();
+
+      // get events
+      const txnEvents = _.groupBy(
+        _.filter(
+          receipt.events?.map((e) => {
+            if (!e.event || !e.args) {
+              return null;
+            }
+
+            return {
+              name: e.event,
+              args: e.args as any[],
+            };
+          }),
+          _.isObject
+        ),
+        'name'
+      );
+
+      hashes.push(receipt.transactionHash);
+      events.push(txnEvents as EncodedTxnEvents);
+    }
 
     return {
-      hash: receipt.transactionHash,
+      hashes,
+      events,
     };
   },
 };

--- a/packages/sample-project/cannonfile.consumer.toml
+++ b/packages/sample-project/cannonfile.consumer.toml
@@ -17,7 +17,7 @@ options.salt = "second"
 options.change_msg = "a message from second greeter set"
 
 [invoke.change_greeting2]
-address = "<%= outputs.greeters.contracts.greeter.address %>"
+addresses = ["<%= outputs.greeters.contracts.greeter.address %>"]
 abi = "<%= outputs.greeters.contracts.greeter.abi %>"
 func = "setGreeting"
 args = ["<%= settings.change_greeting2 %>"]


### PR DESCRIPTION
* allow specifying more than one destination address for call (useful for setting ownership of many contracts, for example)
* allow specifying the `from` address to run a function as owner even if the owner is not available
* support for `fromCall` which can be used to specify a function to call to get the owner address of a contract, for example

lots of things to be getting excited about