### PR TITLE
fix getDepenencies to not fail for unrelated properties

### DIFF
--- a/packages/hardhat-cannon/src/builder/index.ts
+++ b/packages/hardhat-cannon/src/builder/index.ts
@@ -129,7 +129,11 @@ export class ChainBuilder {
 
   getDependencies() {
     if (!this.def.import) return [];
-    return _.uniq(Object.values(this.def.import).map((d) => importSpec.configInject(this.ctx, d).source));
+
+    // we have to apply templating here, only to the `source`
+    // it would be best if the dep was downloaded when it was discovered to be needed, but there is not a lot we
+    // can do about this right now
+    return _.uniq(Object.values(this.def.import).map((d) => _.template(d.source)(this.ctx)));
   }
 
   async build(opts: BuildOptions): Promise<ChainBuilder> {


### PR DESCRIPTION
this will trigger configuration injection only for the `source` property which is needed.

We could be doing a lot better here for config injection, but unfortunately deps
are downloaded befoer the building even starts ,so it is technically possible
for the ctx to be incomplete