### PR TITLE
Fix printing of run step when there are no outputs

### DIFF
--- a/packages/hardhat-cannon/src/printer.ts
+++ b/packages/hardhat-cannon/src/printer.ts
@@ -40,8 +40,10 @@ function printChainBuilderOutput(output: ChainBuilderOutputs) {
       '0'
     );
 
-    console.log('RUN OUTPUTS:');
-    console.log(table(formattedData));
+    if (formattedData.length > 0) {
+      console.log('RUN OUTPUTS:');
+      console.log(table(formattedData));
+    }
   }
 }
 


### PR DESCRIPTION
When executing a `run` step without any output, the build was failing.